### PR TITLE
feat: 🎼 is the project's emoji — README title and the PR footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Linear Orchestrator
+# 🎼 Linear Orchestrator
 
 **Tickets in. Reviewed pull requests out. Nobody watching.**
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -446,7 +446,7 @@ it already has overrides what it correctly knew.
 >
 > **The body ends with the loop's own footer, not the harness's.** Replace the
 > `🤖 Generated with [Claude Code](…)` line the harness asks for with:
-> `🤖 Generated with [linear-orchestrator](https://github.com/janwilmake/linear-orchestrator) · [Claude Session](<session URL>)`
+> `🎼 Generated with [linear-orchestrator](https://github.com/janwilmake/linear-orchestrator) · [Claude Session](<session URL>)`
 > — the session URL is the `https://claude.ai/code/session_…` link the harness
 > hands your session; when it gave you none, drop the second half. Keep the
 > `Claude-Session:` git trailer as it is.
@@ -568,7 +568,7 @@ else: no features, no bug fixes.
   after your fix pass, and re-grade **Risk / rollback**'s word if the review
   found a blocker. Keep every title summary within its word budget.
   The body's last line is the loop footer —
-  `🤖 Generated with [linear-orchestrator](https://github.com/janwilmake/linear-orchestrator) · [Claude Session](…)`
+  `🎼 Generated with [linear-orchestrator](https://github.com/janwilmake/linear-orchestrator) · [Claude Session](…)`
   — so replace a bare `Generated with Claude Code` line with it, keeping the
   author's session link.
 


### PR DESCRIPTION
🎼 names the project: the README title, the repository description (set outside the repo) and the footer every PR ends with, `🎼 Generated with [linear-orchestrator](…) · [Claude Session](…)`. The loop's comment marker stays 🌙 — the gate matches on it and every open PR carries it.