### PR TITLE
fix: tell agents never to leave a background process behind

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -466,6 +466,13 @@ it already has overrides what it correctly knew.
 > image.
 >
 > Do not run `npm install` — `node_modules` is a symlink to the real checkout.
+>
+> **Never leave a background process behind.** A load generator, a watcher or a
+> dev server you start must die before you stop. `jobs -p` is empty in a
+> non-interactive shell, so a cleanup built on it kills nothing: keep each pid as
+> you start it (`(while :; do :; done) & pids="$pids $!"`) and `kill $pids` in a
+> `trap ... EXIT`. Two runs have leaked ten busy loops each at 100% CPU, which
+> starves every other agent and stalls the loop for an hour.
 > Other agents are running dev servers, so take a free port in 5200–5299 and
 > point `VITE_BASE_URL` at it.
 >

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -113,3 +113,22 @@ to `SKILL.md`. The tick itself does not read this.
   clear another's. After a night's run:
   `osascript -e 'tell application "Google Chrome" to get URL of every tab of every window'`
 - **macOS only.** `cca` needs `open -a Terminal` and APFS `cp -Rc`.
+
+## The loop stalls with `load N over 10.0` and almost no agents running
+
+An agent left background processes behind. Seen twice, both times a load
+generator an agent started to reproduce a flaky test under CPU pressure: it
+spawned one busy loop per core and cleaned up with `jobs -p`, which returns
+nothing in a non-interactive shell. Ten shells then ran at 100% CPU under
+launchd until someone noticed, and the capacity gate refused every tick because
+the load it measures was real.
+
+**Find it:** `ps -Ao pid,pcpu,etime,command -r | head` — orphaned shells show a
+`PPID` of 1 and an elapsed time far longer than any live agent.
+
+**Fix it:** `pkill -f '<the exact command pattern>'`. Never kill by cpu alone;
+a build legitimately runs hot.
+
+**Prevent it:** the agent prompt now tells agents to keep pids explicitly and
+kill them in a `trap ... EXIT`. A dev server has the same shape — it survives the
+session and holds memory the gate never sees.


### PR DESCRIPTION
An agent reproducing a flaky test under CPU pressure spawned one busy loop per core and cleaned up with `jobs -p`, which returns nothing in a non-interactive shell. Ten shells then ran at 100% CPU for 82 minutes, and the capacity gate refused every tick because the load was real. This happened twice today, on two different tickets.

**Agent prompt:** keep each pid as you start it and kill it in a `trap ... EXIT`; never rely on `jobs -p`.

**TROUBLESHOOTING.md:** how to spot it (orphaned shells show `PPID` 1 and an elapsed time longer than any live agent), how to kill it by command pattern rather than by CPU, and the note that a dev server has the same shape.