### PR TITLE
fix: retry the gate's PR list and keep its error text

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -228,10 +228,25 @@ probe() {
   # OLDEST open PRs, and an invisible PR is absent from REGATE, DRAFTS and
   # RESTACK alike — which reads exactly like a clean board.
   PR_LIMIT="${LO_PR_LIMIT:-400}"
-  prs=$(gh pr list --repo "$slug" --state open --limit "$PR_LIMIT" \
-    --json number,isDraft,mergeable,body,labels,statusCheckRollup,headRefName,baseRefName 2>/dev/null)
+  # Keep stderr: a discarded one makes every GATE-ERROR undiagnosable, and this
+  # is the call that fails. It is ~5s of GraphQL over every open PR, and GitHub
+  # refuses it intermittently while the agents hammer the same API. `jq` decides
+  # whether the reply is a board, because `gh` exits 0 on some of these.
+  pr_try=$(gh pr list --repo "$slug" --state open --limit "$PR_LIMIT" \
+    --json number,isDraft,mergeable,body,labels,statusCheckRollup,headRefName,baseRefName 2>&1)
+  if ! printf '%s' "$pr_try" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    # One retry. It turns the common transient back into a normal probe instead
+    # of a wake that costs a tick, and two refusals in a row is a real outage.
+    sleep 5
+    pr_try=$(gh pr list --repo "$slug" --state open --limit "$PR_LIMIT" \
+      --json number,isDraft,mergeable,body,labels,statusCheckRollup,headRefName,baseRefName 2>&1)
+  fi
   # A broken gh is itself worth waking for — never wait quietly on it.
-  [ -z "$prs" ] && { echo "GATE-ERROR: gh pr list failed"; return 0; }
+  if ! printf '%s' "$pr_try" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    echo "GATE-ERROR: gh pr list failed — $(printf '%s' "$pr_try" | tr '\n' ' ' | cut -c1-200)"
+    return 0
+  fi
+  prs="$pr_try"
 
   # And say so if it ever binds again, rather than truncating quietly.
   pr_count=$(printf '%s' "$prs" | jq 'length')


### PR DESCRIPTION
The gate reads every open PR in one `gh pr list` call, then treats an empty reply as a failure with its stderr sent to `/dev/null`.

Two things follow from that. GitHub refuses the call intermittently — it is about five seconds of GraphQL over 93 open PRs, made while the agents hammer the same API — so a transient failure wakes the loop and costs a tick. And because the error text is discarded, `GATE-ERROR: gh pr list failed` is all you ever see, which is not enough to tell a network wobble from a broken token.

This retries the call once after five seconds, and prints what `gh` actually said when both tries fail. `jq` decides whether the reply is a board, because `gh` exits 0 on some of these.

The error behind two wakes in ten minutes tonight was `net/http: TLS handshake timeout`, reproduced by hand against the same API a minute later.

Verified by running `gate.sh --peek` on the patched file against the live Hyre board: it returned a normal probe with `REGATE`, `STACK` and `RESTACK` populated.