### PR TITLE
fix: only restack a stack bottom when being behind actually blocks it

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -363,6 +363,20 @@ probe() {
   restack="[]"
   if [ "$(printf '%s' "$stack" | jq 'length')" -gt 0 ]; then
     restack=$(printf '%s' "$stack" | jq -c '.[] | [.pr, .base, .head] | @tsv' -r | while IFS=$'\t' read -r p b h; do
+      # A stack BOTTOM is behind the trunk constantly — the trunk moves all day — and that
+      # only blocks a merge where the strict up-to-date rule is on. GitHub says so itself:
+      # `mergeStateStatus` reads BEHIND exactly then, and CLEAN when being behind costs
+      # nothing. Without this the bottom of every stack sits on RESTACK forever and the
+      # waiter wakes the loop on it every probe, which is what it did.
+      #
+      # Asked per bottom rather than in the bulk list above: `mergeStateStatus` computes
+      # mergeability, and adding it to a 400-PR query answers
+      # "Resource limits for this query exceeded". A stack is rare, so this costs nothing
+      # on the common probe.
+      if [ "$b" = "$BASE" ]; then
+        ms=$(gh pr view "$p" --repo "$slug" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null)
+        [ "$ms" = "BEHIND" ] || continue
+      fi
       cmp=$(gh api "repos/$slug/compare/$b...$h" --jq '.behind_by' 2>/dev/null)
       # A non-numeric answer is a failed lookup, and [ -gt ] returns false for it
       # rather than treating it as a number. `case` cannot be used here: bash


### PR DESCRIPTION
The bottom layer of a stack is behind the trunk constantly, because the trunk moves all day. The gate put every such layer on `RESTACK`, so the waiter woke the loop on the same five entries every probe — five ticks in a row today, each one finding nothing to do and re-arming.

Being behind only blocks a merge where the strict up-to-date rule is on, and GitHub answers that directly: `mergeStateStatus` reads `BEHIND` exactly then, and `CLEAN` when being behind costs nothing.

On the repo this ran against, `dev` has no strict rule — no classic branch protection, and `strict_required_status_checks_policy` is null on the ruleset — and all five flagged bottoms read `CLEAN` with `mergeable: MERGEABLE`. The existing comment in `gate.sh` says the rule was on when the check was written on 31 August; whether it was removed or the observation was wrong, the assumption no longer holds, so the gate now asks instead of assuming.

**Asked per bottom, not in the bulk list.** `mergeStateStatus` computes mergeability, and adding it to the 400-PR query answers `Resource limits for this query exceeded` — I tried that first. A stack is rare, so the common probe pays nothing.

**Upper layers are untouched.** A layer behind the layer below it is a real restack, and that is the case the sweep exists for.

Verified against the live board: before the change `RESTACK` carried five bottoms every probe; after it, the line is absent and the rest of the probe is unchanged.