### PR TITLE
fix: a held draft was hot-looping the waiter every ~28s

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -570,7 +570,16 @@ probe() {
   # Feedback needs no slot to act on: a reply, a re-draft and a follow-up ticket
   # are all free. Only the rework behind it needs an agent.
   [ "$n_feedback" -gt 0 ] && work=yes
-  [ "$slots" -gt 0 ] && [ "$n_drafts" -gt 0 ] && work=yes
+  # A draft already surfaced on a prior probe is not work again on its own — only
+  # a draft whose verdict actually changed since the state file was last saved.
+  # Without the hash check, a draft the model has already looked at and can do
+  # nothing more with (still `CONFLICTING` against a base that has not moved,
+  # blocked on another PR to merge first) reports "work=yes" on every probe
+  # forever: `--wait` never sleeps its `WAIT_INTERVAL`, and instead re-runs the
+  # full forge-reading probe back to back. Seen for real on HYR2-1339's stack:
+  # a held draft woke the waiter roughly every 28s (the probe's own runtime)
+  # for as long as it sat there.
+  [ "$slots" -gt 0 ] && [ "$n_drafts" -gt 0 ] && [ "$hash" != "$prev" ] && work=yes
   # A stale queue is only work when Linear has something to rebuild it FROM.
   # Without this the loop wakes every 30 minutes on an empty ready column, to
   # rebuild an empty file into an identical empty file.


### PR DESCRIPTION
## Problem

\`work=yes\` fired on \`n_drafts > 0\` alone (gate.sh:573), with no check against the saved hash the way the \`todo_ids\` branch two lines below already does. A draft the loop has looked at and genuinely cannot act on further — blocked on another PR merging first, \`CONFLICTING\` against a base that has not moved — reported "work" on every single probe.

In \`--wait\` mode that means the waiter never actually slept its \`WAIT_INTERVAL\`: it woke, ran the full forge-reading probe, found the same draft again, and exited immediately to report it — over and over.

## Cause

Seen live tonight: HYR2-1339 widened in scope mid-flight, its stack layer #1235 went \`CONFLICTING\` against the base while the base itself was being rewritten, and the loop deliberately held it (posted a comment, dispatched no fix) pending the base PR landing. From then on the waiter woke roughly every 28s — the probe's own runtime, not the 60s interval — for as long as #1235 sat in that state.

## Solution

Gate the drafts condition on \`hash != prev\`, matching the existing pattern used for \`todo_ids\`. \`drafts\` is derived from \`verdicts\`, which is already part of the hash, so a draft whose verdict has not moved since the last saved probe no longer forces a wake — while a genuinely new or changed draft still does, immediately.

## Tested by AI

Verified locally: with the state file already holding today's hash (from normal use this session), a bare \`bash gate.sh\` run with #1235 still in \`DRAFTS\` now returns \`NO\` instead of forcing work. Confirmed \`bash -n gate.sh\` passes.

## Risk & rollback

Low. One line gated the same way an adjacent line already is; revert is a one-line diff.