### PR TITLE
chore: stop auto-merging dev into every promoted PR when dev moves

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -296,33 +296,6 @@ probe() {
               elif ([ $c[] | select(.conclusion != "SUCCESS") ] | length) > 0 then "failing"
               else "green" end ) } ] | map(select(.base != "main")) | sort_by(.pr)')
 
-  # --- auto-update: merge $BASE into promoted PRs server-side when it moves ---
-  # Asked for on 31 Aug: when dev advances, refresh every promoted PR that still
-  # merges cleanly, so green means green-on-current-dev without claiming an
-  # agent slot. GitHub's update-branch endpoint does the merge server-side and
-  # answers 422 on a conflict or an already-current branch — conflicts keep
-  # flowing to REGATE as before. Two guards matter:
-  #   - never touch a PR an agent holds: a server-side merge commit under an
-  #     agent's feet turns its next push into a non-fast-forward failure.
-  #   - capped per pass, to bound the CI burst a dev merge wave triggers.
-  # --peek skips the whole pass: a look must not write to the forge.
-  tipfile=~/.claude/linear-orchestrator/dev-tip
-  tip=$(gh api "repos/$slug/commits/$BASE" --jq '.sha' 2>/dev/null)
-  prevtip=$(cat "$tipfile" 2>/dev/null)
-  if [ "$PEEK" != 1 ] && [ -n "$tip" ]; then
-    if [ -n "$prevtip" ] && [ "$tip" != "$prevtip" ]; then
-      updated=0
-      for p in $(printf '%s' "$verdicts" | jq -r --arg b "$BASE" --argjson held "$held" --argjson inhand "$inhand" \
-          '.[] | select(.draft==false and .mine and .base==$b and .merge!="CONFLICTING")
-               | .pr as $p | select($inhand | index($p) | not)
-               | .head as $h | select($held | index($h) | not) | .pr' 2>/dev/null | head -15); do
-        gh api -X PUT "repos/$slug/pulls/$p/update-branch" >/dev/null 2>&1 && updated=$((updated+1))
-      done
-      [ "$updated" -gt 0 ] && notes="$notes${notes:+; }auto-updated $updated promoted pr(s) after $BASE moved"
-    fi
-    printf '%s' "$tip" > "$tipfile"
-  fi
-
   regate=$(printf '%s' "$verdicts" | jq -c --argjson held "$held" --argjson inhand "$inhand" '[ .[]
             | select(.draft==false and .mine)
             | select(.merge=="CONFLICTING" or .ci=="failing")
@@ -347,12 +320,11 @@ probe() {
   # like any other draft, but the model cannot review a stack in an arbitrary
   # order — layer 2 is unreadable before layer 1 — so name the base here and let
   # it sort them bottom-up.
-  # A stack BOTTOM (base == $BASE) belongs here too: GitHub's update-branch
-  # endpoint answers 403 on gh-stack PRs, so the auto-update pass above cannot
-  # refresh it, and with the strict up-to-date rule on (31 Aug) a bottom behind
-  # $BASE blocks its whole stack while every per-PR signal reads green. Including
-  # it hands the RESTACK sweep below a dev...bottom compare, which is the only
-  # thing that notices.
+  # A stack BOTTOM (base == $BASE) belongs here too: nothing refreshes a layer
+  # against $BASE on its own, so a bottom that falls behind blocks its whole
+  # stack while every per-PR signal still reads green. Including it hands the
+  # RESTACK sweep below a dev...bottom compare, which is the only thing that
+  # notices.
   stack=$(printf '%s' "$verdicts" | jq -c --arg b "$BASE" '. as $all | [ .[]
             | select(.mine)
             | select(.base != $b or (.head as $h | ($all | map(select(.base == $h)) | length) > 0))


### PR DESCRIPTION
## Problem

The auto-update pass (added 31 Aug) called GitHub's `update-branch` endpoint on up to 15 promoted PRs every time `dev`'s tip moved, so that a green check meant green against current `dev`.

**Measured on 3 Sep: 441 CI runs in one day**, across 83 branches, median 2 runs per branch — while four PRs from August that nobody pushed a commit to ran **18–19 times each**, purely because `dev` moved under them. Each run is 9 jobs (format, typecheck, lint, build, 4 test shards, mcp) on paid Blacksmith runners.

## Solution

Delete the pass, its `dev-tip` state file, and the now-dangling comment that referenced it.

It is redundant, for two reasons that both live in the app repo's `ci.yml`:

1. The workflow triggers on `pull_request`, and its own comment notes a PR run is `refs/pull/N/merge` — **the PR already merged into its base**. A PR run has never tested the branch in isolation.
2. The repo has a **merge queue**. `merge_group` re-runs the required contexts against `dev` plus every PR ahead in the queue, at merge time — the moment where being current actually decides anything.

So the pass only ever bought an *earlier* warning, and the queue rejects the same PR regardless.

## Risk & rollback

Low. A PR that genuinely cannot merge still reaches the model unchanged: `REGATE` catches `CONFLICTING` and failing CI, which is the case that needs an agent rather than a rebuild. What is lost is the early signal on a PR that merges cleanly but breaks against newer `dev` — the merge queue now catches that.

Rollback is a revert; the deleted block is self-contained.

## Tested by AI

`bash -n gate.sh` passes; `gate.sh --peek` runs and reports normally with the block gone. Grepped for stray references to `tipfile` / `dev-tip` / `update-branch` / `auto-updated` — none left.