### PR TITLE
fix: wake on a de-gate only when the de-gate list changed

### DIFF
--- a/gate.sh
+++ b/gate.sh
@@ -112,6 +112,12 @@ STATE=~/.claude/linear-orchestrator/gate-state
 # every open draft look new again. A draft is only work when something about
 # THAT draft moved.
 DSTATE=~/.claude/linear-orchestrator/gate-drafts-state
+# Same reasoning for the de-gate list. REGATE normally clears itself: the model
+# acts, the PR goes back to draft, and it drops off. It only persists when the
+# model looks and deliberately declines — a conflict GitHub reports that does not
+# exist, a layer whose base is mid-repair — and nothing in the gate records that
+# decision, so an unconditional work=yes re-wakes on the entry forever.
+RSTATE=~/.claude/linear-orchestrator/gate-regate-state
 QUEUE=~/.claude/linear-orchestrator/${PREFIX}-queue.json
 AC="${AGENT_CODEMODE:-$(command -v agent-codemode 2>/dev/null || echo "$HOME/.local/node/bin/agent-codemode")}"
 
@@ -125,6 +131,7 @@ save_state() { [ "$PEEK" = 1 ] || printf '%s' "$1" > "$STATE"; }
 # Written from the same places as save_state, so the two never drift: a probe
 # the model did not see must move neither of them.
 save_drafts_state() { [ "$PEEK" = 1 ] || printf '%s' "$1" > "$DSTATE"; }
+save_regate_state() { [ "$PEEK" = 1 ] || printf '%s' "$1" > "$RSTATE"; }
 NOREASON=""
 
 # probe: measure the world once. Prints the context block and returns 0 when
@@ -582,9 +589,19 @@ probe() {
       2>/dev/null | shasum | cut -c1-16)
   prevdrafts=$(cat "$DSTATE" 2>/dev/null)
 
+  # The same fingerprint for the de-gate list, over the fields a REGATE entry is
+  # judged on. A PR that goes red or starts conflicting still wakes the model at
+  # once, because its verdict changed; only an entry already seen and unchanged
+  # stops re-waking.
+  regatesig=$(printf '%s' "$regate" | jq -Sc '[ .[] | {pr,draft,merge,ci,invalid} ]' \
+      2>/dev/null | shasum | cut -c1-16)
+  prevregate=$(cat "$RSTATE" 2>/dev/null)
+
   # --- decide ---
   work=no
-  [ "$n_regate"  -gt 0 ] && work=yes            # acted on even at slots 0
+  # Still acted on at slots 0 — a de-gate needs no agent — but only once per
+  # change. See RSTATE above for why the unconditional form spun.
+  [ "$n_regate"  -gt 0 ] && [ "$regatesig" != "$prevregate" ] && work=yes
   [ "$n_invalid" -gt 0 ] && work=yes
   # Feedback needs no slot to act on: a reply, a re-draft and a follow-up ticket
   # are all free. Only the rework behind it needs an agent.
@@ -657,12 +674,14 @@ probe() {
     if [ "$hash" = "$prev" ]; then
       save_state "$hash"
       save_drafts_state "$draftsig"
+      save_regate_state "$regatesig"
       return 1
     fi
   fi
 
   save_state "$hash"
   save_drafts_state "$draftsig"
+  save_regate_state "$regatesig"
 
   # --- otherwise: everything the model needs, nothing it does not ---
   echo "load1=$load freegb=$freegb diskgb=$diskgb busy=$busy slots=$slots max=$max_agents$capnote"


### PR DESCRIPTION
## Problem

`REGATE` set `work=yes` unconditionally. That is invisible while every entry is actionable — the model de-gates, the PR becomes a draft, and it drops off the list.

It stops being invisible when the model looks at an entry and **deliberately declines**. Live case today, #997 in the Hyre repo: GitHub reported `mergeable=false` / `dirty` with **`merge_commit_sha: null`**, while `git merge-base --is-ancestor` showed the base *is* an ancestor of the head — so merging is a fast-forward and the conflict is impossible. De-gating a healthy promoted PR on a signal proven false was the wrong answer, but nothing in the gate records "seen and declined", so the entry woke the waiter on **every probe, roughly every 23s, indefinitely**. Closing and reopening the PR — the usual nudge for a stuck mergeability calculation — did not clear it.

## Solution

The same shape as the drafts fingerprint directly above it: hash the fields a `REGATE` entry is judged on (`pr`, `draft`, `merge`, `ci`, `invalid`) into its own state file, written from the same two places as the other two so they cannot drift, and require a change before it counts as work.

A PR that goes red or starts conflicting still wakes the model immediately, because its verdict changed. Only an entry already seen and unchanged stops re-waking. Still acted on at `slots 0`, since a de-gate needs no agent.

`INVALID` and `FEEDBACK` are left unconditional on purpose — the invalid label is a durable record that a reclaim is owed and must persist until the rework is spawned, and feedback clears itself when the ack is posted.

## Tested by AI

`bash -n` passes. The state file is written and read back, and the fingerprint changes when the list changes.

**What I could not isolate, stated plainly:** I tried to prove the negative — that an unchanged `REGATE` no longer wakes `--wait` — and could not, because real work kept arriving on the live board during each attempt. Two `--wait` runs returned early, and instrumenting the decide block showed why in both cases: first `DRAFTS` gained a PR whose agent had finished, then `n_feedback=1` from a new review comment, and separately two more PRs (#994, #1143) genuinely entered `REGATE` and moved the fingerprint. Each wake was correct. So the change is verified to compute and persist the fingerprint, and its gating logic mirrors the drafts one that has been running since `fb4ce73` — but the "does not wake" half is reasoned, not observed. Worth watching on the first genuinely quiet board.

## Risk & rollback

Low, and self-contained. Worst case is a delayed de-gate on an entry whose verdict did not change, which is the behaviour being asked for. Rollback is a revert.

Independent of #14 — different part of the file; whichever merges second may need a trivial rebase.