### PR TITLE
docs: carry the marker rule the hyre repo is dropping

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -438,11 +438,21 @@ it already has overrides what it correctly knew.
 >
 > Never use a file or line count as a risk proxy.
 >
-> **It stays a draft** (`gh pr create --draft`) and you never take it out. Start
-> the body with:
+> **It stays a draft** (`gh pr create --draft`) and you never take it out.
+>
+> **The marker goes on the second line of the body, under the ticket link:**
 > `🌙 lo:<OWNER> opened by the nightly orchestrator. Not seen by a human. Read the Decisions section before merging.`
-> (drop ` lo:<OWNER>` when it is empty). A PR without the tag is invisible to its
-> own loop; one with the wrong tag gets reviewed by the wrong machine.
+> Both want the first line and the ticket link wins, because the ticket is what a
+> reviewer judges the scope against. **`<OWNER>` is the literal value of
+> `LO_OWNER`** — the dispatching tick substitutes it and passes the finished
+> string, because an agent cannot read that config and a placeholder left
+> unresolved is the same as no tag. Drop ` lo:<OWNER>` only when `LO_OWNER` is
+> genuinely empty.
+>
+> A PR without the tag is invisible to its own loop — not in its drafts, and not
+> in its feedback scan, so a reviewer's blocker goes unanswered. One with the
+> wrong tag gets reviewed by the wrong machine. The gate cannot tell a malformed
+> marker from another team's PR, so this failure is silent.
 >
 > **The body ends with the loop's own footer, not the harness's.** Replace the
 > `🤖 Generated with [Claude Code](…)` line the harness asks for with:


### PR DESCRIPTION
Pairs with **Hyre-AI-Recruiting/hyre#1259**, which deletes the repo's copy of this rule. Correct only together: that PR removes the line placement, this one carries it.

## The bug this closes

Six of today's PRs opened with a bare `🌙` instead of `🌙 lo:hyre`, and were invisible to the loop that opened them — absent from `DRAFTS`, absent from the feedback scan. #1254 sat on an unanswered reviewer blocker for over two hours.

Two causes, both in the wording rather than the code:

1. **`<OWNER>` was never resolved.** The skill hands the agent `🌙 lo:<OWNER>` and adds "(drop ` lo:<OWNER>` when it is empty)". `LO_OWNER` lives in this skill's `.env`, which an agent has no reason to open — it boots in a copy of the target repo. So an agent that reaches this text sees an unresolvable placeholder, reads the escape clause, and writes the bare marker. The tick has to substitute the value before dispatch; nothing said so.

2. **The line placement lived in the other repo.** Hyre's `opening-a-pr` skill and PR template both described the marker, as a bare `🌙`, and put it on the second line under the ticket link with a stated reason. That is the file an agent actually loads when opening a PR, so it is the one it followed. hyre#1259 deletes those, correctly — the owner tag is per-machine, and a repo documenting it is documenting one laptop.

Deleting hyre's copy without adding the ordering here would lose it, and leave this skill saying "start the body with", which is the opposite of what the repo intended.

## What changed

The draft-PR paragraph in **The agent prompt** now states:

- The marker goes on the **second line, under the ticket link**, and why — the ticket is what a reviewer judges scope against.
- **`<OWNER>` is the literal value of `LO_OWNER`**, substituted by the dispatching tick, because an agent cannot read that config and an unresolved placeholder is the same as no tag.
- The consequence, in the terms that make it worth caring about: a missing tag means invisible to its own loop, in both the draft list and the feedback scan, and the gate cannot distinguish a malformed marker from another team's PR — so the failure is silent.

Documentation only. No change to `gate.sh` or any behaviour.

## Still open, deliberately

The silence is the root problem: a malformed marker and another team's PR look identical to the gate. Wording reduces how often agents get it wrong; it cannot make a mistake visible. A guard — refusing a `🌙` with no owner tag at PR-open time, or a periodic scan for one — would turn a silent loss into a reported error. Not in this PR, which is a docs fix.

Note also that #14 and #15 remain open on this repo. This branch is cut from `main` and touches only `SKILL.md`, so it conflicts with neither.
